### PR TITLE
build(agla-error): initialize package with configs, build setup, and entry point

### DIFF
--- a/.vscode/cspell/dicts/project.dic
+++ b/.vscode/cspell/dicts/project.dic
@@ -1,4 +1,8 @@
 # this files is words list for check spell on cSpell
 aglogger
+cjs
 CODEOWNERS
+esm
+ESM
 stylelintcache
+tsup

--- a/base/configs/tsconfig.base.json
+++ b/base/configs/tsconfig.base.json
@@ -13,6 +13,7 @@
     ".git",
     "dist",
     "lib",
+    "maps",
     "module",
     "node_modules",
     ".cache",

--- a/packages/@aglabo/agla-error/.gitignore
+++ b/packages/@aglabo/agla-error/.gitignore
@@ -71,7 +71,6 @@ $~*
 dist
 **/module/*
 **/lib/*
-maps
 
 # Test Report
 *results/*

--- a/packages/@aglabo/agla-error/.gitignore
+++ b/packages/@aglabo/agla-error/.gitignore
@@ -69,8 +69,10 @@ $~*
 # Node.js / JS project ignores
 # Output directory
 dist
-**/module/*
-**/lib/*
+module
+lib
+# Types (xxx.d.ts)
+maps/*
 
 # Test Report
 *results/*

--- a/packages/@aglabo/agla-error/configs/commitlint.config.ts
+++ b/packages/@aglabo/agla-error/configs/commitlint.config.ts
@@ -1,0 +1,24 @@
+// src: shared/common/configs/commitlint.config.ts
+// @(#) : commitlint configuration for common workspace
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// import commitlint config type
+import { default as baseConfig } from '../../../../base/configs/commitlint.config.base.js'; // ← .js拡張子を必ず付ける
+
+import type { UserConfig } from '@commitlint/types';
+
+// import base Config
+
+const config: UserConfig = {
+  ...baseConfig,
+  rules: {
+    ...baseConfig.rules,
+    // override rules write here
+  },
+};
+
+export default config;

--- a/packages/@aglabo/agla-error/configs/eslint.config.js
+++ b/packages/@aglabo/agla-error/configs/eslint.config.js
@@ -1,0 +1,34 @@
+// src: shared/common/configs/eslint.config.js
+// @(#) : ESLint flat config for TypeScript workspace
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs
+
+// import form common base config
+import baseConfig from '../../../../base/configs/eslint.config.base.js';
+
+// settings
+export default [
+  ...baseConfig,
+
+  // source code settings
+  {
+    files: [
+      'index.ts',
+      'src/**/*.ts',
+      'types/**/*.ts',
+      'tests/**/*.ts',
+    ],
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: './tsconfig.json',
+        },
+      },
+    },
+  },
+];

--- a/packages/@aglabo/agla-error/configs/eslint.config.typed.js
+++ b/packages/@aglabo/agla-error/configs/eslint.config.typed.js
@@ -1,0 +1,51 @@
+// src: shared/common/configs/eslint.config.typed.js
+// @(#) : ESLint flat config for type check
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// resolve root directory
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+// directories
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const __rootDir = path.resolve(__dirname, '..');
+
+// parser
+import tsparser from '@typescript-eslint/parser';
+
+// import form common base config
+import baseConfig from '../../../../base/configs/eslint.config.typed.base.js';
+
+export default [
+  ...baseConfig,
+
+  // --- source codes settings
+  {
+    files: [
+      'index.ts',
+      'src/**/*.ts',
+      'types/**/*.ts',
+      'tests/**/*.ts',
+    ],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: __rootDir,
+        sourceType: 'module',
+      },
+    },
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: './tsconfig.json',
+        },
+      },
+    },
+  },
+];

--- a/packages/@aglabo/agla-error/configs/secretlint.config.yaml
+++ b/packages/@aglabo/agla-error/configs/secretlint.config.yaml
@@ -1,0 +1,10 @@
+# src: shared/configs/secretlint.config.base.yaml
+# @(#) : secretlint base configuration
+#
+# Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+rules:
+  - id: "@secretlint/secretlint-rule-preset-recommend"

--- a/packages/@aglabo/agla-error/configs/tsup.config.cjs.ts
+++ b/packages/@aglabo/agla-error/configs/tsup.config.cjs.ts
@@ -1,0 +1,30 @@
+// src: shared/common/configs/tsup.config.ts
+// @(#) : tsup config for CommonJS module
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// system config
+import { defineConfig } from 'tsup';
+
+// user config
+import { baseConfig } from '../../../../base/configs/tsup.config.base';
+
+export default defineConfig({
+  ...baseConfig,
+
+  // entry points
+  entry: {
+    'index': './src/index.ts',
+  },
+
+  // sub packages definition
+  format: ['cjs'],
+  outDir: 'lib', // for CJS
+  // tsconfig
+  tsconfig: './tsconfig.json',
+  // DTS with incremental build for CJS
+  dts: false,
+});

--- a/packages/@aglabo/agla-error/configs/tsup.config.esm.ts
+++ b/packages/@aglabo/agla-error/configs/tsup.config.esm.ts
@@ -1,0 +1,31 @@
+// src: shared/common/configs/tsup.config.module.ts
+// @(#) : tsup config for ESM module
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// system config
+import { defineConfig } from 'tsup';
+
+// user config
+import { baseConfig } from '../../../../base/configs/tsup.config.base';
+
+// configs
+export default defineConfig({
+  ...baseConfig,
+
+  // entry points
+  entry: {
+    'index': './src/index.ts',
+  },
+
+  // sub-packages definition
+  format: ['esm'],
+  outDir: 'module', // for ESM
+  // tsconfig
+  tsconfig: './tsconfig.json',
+  // DTS with incremental build for ESM
+  dts: true,
+});

--- a/packages/@aglabo/agla-error/configs/vitest.config.e2e.ts
+++ b/packages/@aglabo/agla-error/configs/vitest.config.e2e.ts
@@ -1,0 +1,46 @@
+// src: shared/common/configs/vitest.config.e2e.ts
+// @(#) : vitest config for end-to-end test
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs for base directory
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+// base directory
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const __rootDir = path.relative(__dirname, '../');
+
+// system config
+import { mergeConfig } from 'vitest/config';
+
+// shared base config
+import baseConfig from '../../../../base/configs/vitest.config.base';
+
+// config
+export default mergeConfig(baseConfig, {
+  test: {
+    include: [
+      // CI (End-to-End) Tests
+      'tests/e2e/**/*.test.ts',
+      'tests/e2e/**/*.spec.ts',
+    ],
+    exclude: [
+      '**/__tests__/*',
+    ],
+    cacheDir: path.resolve(__rootDir, '.cache/vitest-cache/e2e/'),
+    // parallel test
+    sequence: {
+      concurrent: true,
+    },
+  },
+  resolve: {
+    alias: [
+      { find: '@', replacement: path.resolve(__rootDir, './src') },
+      { find: /^@\/shared/, replacement: path.resolve(__rootDir, './shared') },
+    ],
+  },
+});

--- a/packages/@aglabo/agla-error/configs/vitest.config.functional.ts
+++ b/packages/@aglabo/agla-error/configs/vitest.config.functional.ts
@@ -1,0 +1,55 @@
+// src: shared/common/configs/vitest.config.functional.ts
+// @(#) : vitest config for functional test
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs for base directory
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+// base directory
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const __rootDir = path.relative(__dirname, '../');
+
+// system config
+import { mergeConfig } from 'vitest/config';
+
+// shared base config
+import baseConfig from '../../../../base/configs/vitest.config.base';
+
+// config
+export default mergeConfig(baseConfig, {
+  test: {
+    include: [
+      // Functional Test - single feature complete behavior verification
+      'src/**/__tests__/functional/**/*.spec.ts',
+      'src/**/__tests__/functional/**/*.test.ts',
+    ],
+    exclude: [
+      'src/**/__tests__/units/**/*',
+      'tests/**/*',
+    ],
+    cacheDir: path.resolve(__rootDir, '.cache/vitest-cache/functional/'),
+    // sequential test execution to avoid singleton state conflicts in functional tests
+    sequence: {
+      concurrent: false,
+    },
+    //
+    coverage: {
+      reporter: ['text'],
+      exclude: [
+        '**/node_modules/**',
+        'configs/**',
+        'tests/**',
+      ],
+    },
+  },
+  resolve: {
+    alias: [
+      { find: '@', replacement: path.resolve(__rootDir, './src') },
+      { find: /^@\/shared/, replacement: path.resolve(__rootDir, './shared') },
+    ],
+  },
+});

--- a/packages/@aglabo/agla-error/configs/vitest.config.integration.ts
+++ b/packages/@aglabo/agla-error/configs/vitest.config.integration.ts
@@ -1,0 +1,45 @@
+// src: shared/common/configs/vitest.config.ci.ts
+// @(#) : vitest config for CI test
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs for base directory
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+// base directory
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const __rootDir = path.relative(__dirname, '../');
+
+// system config
+import { mergeConfig } from 'vitest/config';
+
+// shared base config
+import baseConfig from '../../../../base/configs/vitest.config.base';
+
+// config
+export default mergeConfig(baseConfig, {
+  test: {
+    include: [
+      // CI (Integration) Tests
+      'tests/integration/**/*.test.ts',
+      'tests/integration/**/*.spec.ts',
+    ],
+    exclude: [
+      '**/__tests__/*',
+    ],
+    cacheDir: path.resolve(__rootDir, '.cache/vitest-cache/ci/'),
+    // parallel test
+    sequence: {
+      concurrent: true,
+    },
+  },
+  resolve: {
+    alias: {
+      '@/shared': path.resolve(__rootDir, './shared/'),
+      '@': path.resolve(__rootDir, './src'),
+    },
+  },
+});

--- a/packages/@aglabo/agla-error/configs/vitest.config.unit.ts
+++ b/packages/@aglabo/agla-error/configs/vitest.config.unit.ts
@@ -1,0 +1,55 @@
+// src: shared/common/configs/vitest.config.unit.ts
+// @(#) : vitest config for unit test
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs for base directory
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+// base directory
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const __rootDir = path.relative(__dirname, '../');
+
+// system config
+import { mergeConfig } from 'vitest/config';
+
+// shared base config
+import baseConfig from '../../../../base/configs/vitest.config.base';
+
+// config
+export default mergeConfig(baseConfig, {
+  test: {
+    include: [
+      // Unit Test - pure unit tests for individual functions/methods
+      'src/**/__tests__/**/*.spec.ts',
+      'src/**/__tests__/**/*.test.ts',
+    ],
+    exclude: [
+      'src/**/__tests__/functional/**/*',
+      'tests/**/*',
+    ],
+    cacheDir: path.resolve(__rootDir, '.cache/vitest-cache/unit/'),
+    // sequential test execution to avoid singleton state conflicts
+    sequence: {
+      concurrent: false,
+    },
+    //
+    coverage: {
+      reporter: ['text'],
+      exclude: [
+        '**/node_modules/**',
+        'configs/**',
+        'tests/**',
+      ],
+    },
+  },
+  resolve: {
+    alias: [
+      { find: '@', replacement: path.resolve(__rootDir, './src') },
+      { find: /^@\/shared/, replacement: path.resolve(__rootDir, './shared') },
+    ],
+  },
+});

--- a/packages/@aglabo/agla-error/package.json
+++ b/packages/@aglabo/agla-error/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@aglabo/agla-error",
+  "_comment": "@(#) AglaError: standardized error handling with AglaError class and ErrorSeverity enum",
+  "private": true,
+  "version": "0.1.0",
+  "description": "AglaError class and ErrorSeverity enum for standardized error handling",
+  "author": "atsushifx <https://github.com/atsushifx>",
+  "license": "MIT",
+  "type": "module",
+  "main": "./module/index.js",
+  "types": "./maps/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./maps/src/index.d.ts",
+      "import": "./module/index.js",
+      "require": "./lib/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "pnpm run build:cjs && pnpm run build:esm & pnpm run build:types",
+    "build:cjs": "tsup --config ./configs/tsup.config.cjs.ts",
+    "build:esm": "tsup --config ./configs/tsup.config.esm.ts",
+    "build:types": "tsc -p ./tsconfig.json",
+    "clean": "rimraf lib module .cache",
+    "format:dprint": "dprint fmt",
+    "check:dprint": "dprint check",
+    "check:types": "tsc --noEmit --incremental",
+    "check:spells": "cspell --config .vscode/cspell.json --cache --cache-location .cache/cspell/cSpellCache",
+    "lint": "pnpm exec eslint --config ./configs/eslint.config.js --cache --cache-location .cache/eslint-cache/esLintCache ",
+    "lint:types": "pnpm exec eslint --config ./configs/eslint.config.typed.js --cache --cache-location .cache/eslint-cache/esLintTypedCache",
+    "lint:all": "pnpm run lint && pnpm run lint:types",
+    "lint:fix": "pnpm run lint --fix",
+    "lint:secrets": "secretlint --secretlintrc ./configs/secretlint.config.yaml --secretlintignore .gitignore --maskSecrets **/*",
+    "test:all": "pnpm run test:develop && pnpm run test:functional && pnpm run test:ci && pnpm run test:e2e",
+    "test:develop": "pnpm exec vitest run --config ./configs/vitest.config.unit.ts",
+    "test:functional": "pnpm exec vitest run --config ./configs/vitest.config.functional.ts",
+    "test:ci": "pnpm exec vitest run --config ./configs/vitest.config.integration.ts",
+    "test:e2e": "pnpm exec vitest run --config ./configs/vitest.config.e2e.ts",
+    "sync:configs": "bash ../../../scripts/sync-configs.sh . "
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/@aglabo/agla-error/src/index.ts
+++ b/packages/@aglabo/agla-error/src/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+export {}
+

--- a/packages/@aglabo/agla-error/tsconfig.json
+++ b/packages/@aglabo/agla-error/tsconfig.json
@@ -1,0 +1,29 @@
+// src: ./tsconfig.json
+// @(#) : typescript compile settings
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+{
+  "extends": "../../../base/configs/tsconfig.base.json",
+  "include": [
+    "types/*.ts",
+    "src/**/*.ts",
+    "tests/**/*.ts"
+  ],
+  "exclude": [],
+  "compilerOptions": {
+    // directories
+    "declarationDir": "./maps",
+    // "outDir": "./maps",
+    "rootDir": "./",
+    // aliases
+    "baseUrl": "./",
+    // "paths": {},
+    // types
+    // cache
+    "incremental": true,
+    "tsBuildInfoFile": ".cache/tsbuild-cache/tsBuildInfo.json"
+  }
+}


### PR DESCRIPTION
## ✨ Overview

This Pull Request sets up the **initial configuration and build system for the `agla-error` package**.  
It introduces TypeScript and bundler settings, standardized lint/test configs, and an initial package structure.  

The goal is to establish a consistent foundation for error handling functionality and future package development.

---

## 🔧 Changes

- [x] Added/updated files or modules  
- [ ] Removed deprecated logic or configs  
- [x] Refactored for clarity/performance  
- [x] Other (please describe below)  

**Details:**
- Added initial `package.json` with scripts for build, lint, and test  
- Fixed `types` path to `maps/src/index.d.ts` and updated `exports.types` accordingly  
- Added TypeScript config with incremental builds enabled  
- Added **tsup** configs for CommonJS and ESM builds (based on shared base)  
- Updated `.gitignore` to exclude `module`, `lib`, and `maps` directories  
- Added lint/test/security configs:
  - **commitlint** (extends base rules)  
  - **ESLint** (standard + typed configs for TypeScript)  
  - **secretlint** (basic recommended rules)  
  - **Vitest** configs for unit, functional, integration, and e2e  
- Updated `cSpell` dictionary with project-specific terms  
- Added empty `index.ts` with MIT license header as package entry point  

---

## 📂 Related Issues

N/A

---

## ✅ Checklist

- [x] Lint checks pass (`pnpm lint`)  
- [ ] Tests pass (`pnpm test`)  
- [ ] Documentation is updated (if applicable)  
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)  
- [ ] Descriptions and examples are clear  

---

## 💬 Additional Notes

This PR finalizes the **initial setup for `agla-error`**, ensuring that the package is build-ready, lint-ready, and test-ready.  
Future work will focus on implementing error handling logic and integrating with other ESTA packages.
